### PR TITLE
Xdebug setting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         restart: on-failure
         environment:
             APP_ENV: dev
-            XDEBUG_CONFIG: "remote_host=host.docker.symfony-network remote_enable=1 remote_autostart=1 remote_handler=\"dbgp\"  remote_port=9000"
+            #XDEBUG_CONFIG: "remote_host=host.docker.symfony-network remote_enable=1 remote_autostart=1 remote_handler=\"dbgp\"  remote_port=9000"
         volumes:
             - ./:/var/www/symfony/
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
         restart: on-failure
         environment:
             APP_ENV: dev
-            #XDEBUG_CONFIG: "remote_host=host.docker.symfony-network remote_enable=1 remote_autostart=1 remote_handler=\"dbgp\"  remote_port=9000"
         volumes:
             - ./:/var/www/symfony/
         networks:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -18,5 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pgsql pdo pdo_pgsql
 
 ADD ./php.ini /usr/local/etc/php/php.ini
+COPY conf.d/                        /usr/local/etc/php/conf.d
 
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/getcomposer

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -18,6 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pgsql pdo pdo_pgsql
 
 ADD ./php.ini /usr/local/etc/php/php.ini
-COPY conf.d/                        /usr/local/etc/php/conf.d
+COPY conf.d/  /usr/local/etc/php/conf.d
 
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/getcomposer

--- a/docker/php/conf.d/99-xdebug.ini
+++ b/docker/php/conf.d/99-xdebug.ini
@@ -1,0 +1,10 @@
+[xdebug]
+xdebug.remote_autostart=0
+xdebug.remote_enable=1
+xdebug.remote_connect_back=1
+xdebug.remote_handler=dbgp
+xdebug.remote_port=9000
+xdebug.remote_mode=req
+xdebug.idekey=
+# https://xdebug.org/docs/all#file_link_format
+xdebug.file_link_format=xdebug://%f@%l

--- a/src/Controller/WelcomeController.php
+++ b/src/Controller/WelcomeController.php
@@ -16,7 +16,11 @@ class WelcomeController extends AbstractController
         $em->getConnection()->connect();
         $connected = $em->getConnection()->isConnected();
 
-        //dump($connected);
+        /**
+         * Set mapping in File/Settings/PHP/Servers
+         * Add breakpoint to the next line
+         */
+        dump($connected);
         phpinfo();
         die;
 


### PR DESCRIPTION
Так у меня работает. Дропаешь старые контейнеры (docker-compose down), собираешь новые (docker-compose up -d --build)
Xdebug я тестирую в мозилле с помощью плагина: он добавляет жука в строку с URL и какой-то параметр в запрос (забыл какой :) )